### PR TITLE
validating product using slug

### DIFF
--- a/app/models/odoo/order_line.rb
+++ b/app/models/odoo/order_line.rb
@@ -16,7 +16,8 @@ module Odoo
     end
 
     def product
-      @product ||= ProductProduct.find(name: line_item.name).first
+      binding.pry
+      @product ||= ProductProduct.find(default_code: line_item.product.slug).first
     end
 
     private

--- a/app/models/odoo/order_line.rb
+++ b/app/models/odoo/order_line.rb
@@ -16,7 +16,6 @@ module Odoo
     end
 
     def product
-      binding.pry
       @product ||= ProductProduct.find(default_code: line_item.product.slug).first
     end
 


### PR DESCRIPTION
## Changes made
- Issue: It is too easy to create a mistake you can either misspell the product name or add an extra space. 

Solution: Add to product to odoo using the slug. That way the product can always be found. 