### PR TITLE
Feature/qa revisions

### DIFF
--- a/app/models/odoo/country.rb
+++ b/app/models/odoo/country.rb
@@ -1,9 +1,10 @@
 module Odoo
   class Country
-    def self.find(order)
-      country_name = order.ship_address.country.name
+    def self.find(address)
+      country_name = address.country.name
       ResCountry.find(name: country_name).first
     end
   end
 end
+
 

--- a/app/models/odoo/order.rb
+++ b/app/models/odoo/order.rb
@@ -29,3 +29,4 @@ module Odoo
     end
   end
 end
+

--- a/app/models/odoo/order.rb
+++ b/app/models/odoo/order.rb
@@ -13,7 +13,9 @@ module Odoo
     end
 
     def save
-      SaleOrder.create(partner_id: partner.id, order_line: order_lines)
+      SaleOrder.create(partner_id: partner.id,
+                       order_line: order_lines,
+                       name: order.number)
     end
 
     def partner

--- a/app/models/odoo/order.rb
+++ b/app/models/odoo/order.rb
@@ -13,9 +13,11 @@ module Odoo
     end
 
     def save
-      SaleOrder.create(partner_id: partner.id,
+      SaleOrder.create(partner_id: partner.odoo_partner.id,
                        order_line: order_lines,
-                       name: order.number)
+                       name: order.number,
+                       invoice_partner_id: partner.invoice_partner.id,
+                       delivery_partner_id: partner.delivery_partner.id)
     end
 
     def partner

--- a/app/models/odoo/order_line.rb
+++ b/app/models/odoo/order_line.rb
@@ -24,7 +24,7 @@ module Odoo
       {
         name: product.name,
         product_id: product.id,
-        price_unit: line_item.total_total_excluding_vat.to_s,
+        price_unit: line_item.total_excluding_vat.to_s,
         product_uom_qty: line_item.quantity
       }
     end

--- a/app/models/odoo/order_line.rb
+++ b/app/models/odoo/order_line.rb
@@ -24,7 +24,7 @@ module Odoo
       {
         name: product.name,
         product_id: product.id,
-        price_unit: line_item.total.to_s,
+        price_unit: line_item.total_total_excluding_vat.to_s,
         product_uom_qty: line_item.quantity
       }
     end

--- a/app/models/odoo/partner.rb
+++ b/app/models/odoo/partner.rb
@@ -6,6 +6,7 @@ module Odoo
     def self.find_or_create(order)
       partner = self.new(order)
       partner.create unless partner.odoo_partner
+      partner.create_children
       partner
     end
 
@@ -20,8 +21,11 @@ module Odoo
 
     def create
       @odoo_partner = ResPartner.create partner_attributes(order.ship_address)
-      @invoice_partner = ResPartner.create partner_attributes(order.bill_address).merge(name: "billing", type: "invoice", parent_id: @odoo_partner.id)
-      @delivery_partner = ResPartner.create partner_attributes(order.ship_address).merge(name: "shipping", type: "delivery", parent_id: @odoo_partner.id)
+    end
+
+    def create_children
+      @invoice_partner = ResPartner.create partner_attributes(order.bill_address).merge(name: "billing", type: "invoice", parent_id: odoo_partner.id)
+      @delivery_partner = ResPartner.create partner_attributes(order.ship_address).merge(name: "shipping", type: "delivery", parent_id: odoo_partner.id)
     end
 
     private

--- a/app/models/odoo/partner.rb
+++ b/app/models/odoo/partner.rb
@@ -1,12 +1,12 @@
 module Odoo
   class Partner
 
-    attr_accessor :order, :state, :country, :odoo_partner
+    attr_accessor :order, :odoo_partner, :invoice_partner, :delivery_partner
 
     def self.find_or_create(order)
       partner = self.new(order)
-      partner.odoo_partner && partner.update || partner.create
-      partner.odoo_partner
+      partner.create unless partner.odoo_partner
+      partner
     end
 
     def initialize(order)
@@ -18,37 +18,35 @@ module Odoo
       ResPartner.find(email: order.email).first
     end
 
-    def update
-      odoo_partner.update(partner_attributes)
-      odoo_partner.save
-    end
-
     def create
-      ResPartner.create(partner_attributes)
+      @odoo_partner = ResPartner.create partner_attributes(order.ship_address)
+      @invoice_partner = ResPartner.create partner_attributes(order.bill_address).merge(name: "billing", type: "invoice", parent_id: @odoo_partner.id)
+      @delivery_partner = ResPartner.create partner_attributes(order.ship_address).merge(name: "shipping", type: "delivery", parent_id: @odoo_partner.id)
     end
 
     private
-    def partner_attributes
+    def partner_attributes(address)
       {
         name: order.name,
-        street: order.ship_address.address1,
-        city: order.ship_address.city,
-        state_id: state.id,
-        zip: order.ship_address.zipcode,
-        country_id: country.id,
-        phone: order.ship_address.phone,
-        email: order.email,
-        function: order.number #provisional while testing
+        street: address.address1,
+        city: address.city,
+        state_id: state(address).id,
+        zip: address.zipcode,
+        country_id: country(address).id,
+        phone: address.phone,
+        email: order.email
       }
     end
 
-    def state
-      @state ||= State.find(order)
+    def state(address)
+      State.find(address)
     end
 
-    def country
-      @country ||= Country.find(order)
+    def country(address)
+      Country.find(address)
     end
 
   end
 end
+
+

--- a/app/models/odoo/state.rb
+++ b/app/models/odoo/state.rb
@@ -1,8 +1,9 @@
 module Odoo
   class State
-    def self.find(order)
-      state_name = order.ship_address.state.name
+    def self.find(address)
+      state_name = address.state.name
       ResCountryState.find(name: state_name).first
     end
   end
 end
+


### PR DESCRIPTION
## Fixes:

- VAT calculation disparity between Solidus and Odoo
- Lack of reference to Solidus Order Number on Odoo Sale Order
- Misconfiguration of Delivery and Invoice Addresses on Odoo Sale Order

## Changes:

- Use Order Number as Reference for Name Odoo Sale Order 
- User Line Item Prices without VAT as Price Unit on Odoo Order Line
- Create Partner with Children Delivery and Invoice Addresses Types 


![Alt text](https://monosnap.com/file/0ECEFRgR0XJp3PNPxlz8H6Ep89K1Xi.png)

![Alt text](https://monosnap.com/file/YcF55vWa9QFPgpa7kQTSzaDDcJNDUi.png)

![Alt text](https://monosnap.com/file/tYCNyV2bdalMQeutf1B85DX8PUcfAE.png)